### PR TITLE
Mahalanobis distance penalty

### DIFF
--- a/src/Penalties.jl
+++ b/src/Penalties.jl
@@ -14,7 +14,8 @@ export
             SCADPenalty,
         ArrayPenalty,
             NuclearNormPenalty,
-            GroupLassoPenalty
+            GroupLassoPenalty,
+            MahalanobisPenalty
 
 typealias AA{T, N} AbstractArray{T, N}
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -67,7 +67,7 @@ type MahalanobisPenalty{T <: Number} <: ArrayPenalty
 end
 MahalanobisPenalty{T}(C::AA{T}) = MahalanobisPenalty(one(T),C)
 
-value{T <: Number}(p::MahalanobisPenalty{T}, x) = p.λ*sumabs2(p.C*x)
+value{T <: Number}(p::MahalanobisPenalty{T}, x) = T(0.5)*p.λ*sumabs2(p.C*x)
 
 function _prox!{T <: Number}(p::MahalanobisPenalty{T}, A::AA{T, 1}, s::T)
     y = (p.C'p.C + (one(T)/s)*I) \ (A./s)

--- a/src/array.jl
+++ b/src/array.jl
@@ -54,3 +54,22 @@ function _prox!{T <: Number}(p::GroupLassoPenalty{T}, A::AA{T, 1}, s::T)
     end
     A
 end
+
+#-----------------------------------------------------------------# MahalanobisPenalty
+"""
+    MahalanobisPenalty(C)
+
+Supports a Mahalanobis distance penalty (`xᵀCᵀCx` for a vector `x`).
+"""
+type MahalanobisPenalty{T <: Number} <: ArrayPenalty
+    λ::T
+    C::AA{T,2}
+end
+MahalanobisPenalty{T}(C::AA{T}) = MahalanobisPenalty(one(T),C)
+
+value{T <: Number}(p::MahalanobisPenalty{T}, x) = p.λ*sumabs2(p.C*x)
+
+function _prox!{T <: Number}(p::MahalanobisPenalty{T}, A::AA{T, 1}, s::T)
+    y = (p.C'p.C + (one(T)/s)*I) \ (A./s)
+    copy!(A,y)
+end

--- a/src/elementwise.jl
+++ b/src/elementwise.jl
@@ -68,6 +68,8 @@ deriv{T<:Number}(p::ElementwisePenalty, x::T, s::T) = s * deriv(p, x)
 prox(p::ElementwisePenalty, x::Number) = _prox(p, x, p.λ)
 prox{T<:Number}(p::ElementwisePenalty, x::T, s::T) = _prox(p, x, p.λ * s)
 
+prox{T<:Number}(p::ElementwisePenalty, x::AA{T}) = prox!(p, copy(x))
+prox{T<:Number}(p::ElementwisePenalty, x::AA{T}, s) = prox!(p, copy(x), s)
 
 #-------------------------------------------------------------------------# NoPenalty
 "No Penalty: f(x) = 0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ using LearnBase, Penalties, Base.Test
     @testset "MahalanobisPenalty" begin
         p = MahalanobisPenalty(eye(10))
         β = ones(10)
-        @test value(p, β) ≈ sum(β.^2)
+        @test value(p, β) ≈ 0.5*sum(β.^2)
         @test prox(p, β) ≈ prox(L2Penalty(1.0), β)
 
         # TODO: add more tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,8 +44,13 @@ using LearnBase, Penalties, Base.Test
         β = ones(10)
         @test value(p, β) ≈ 0.5*sum(β.^2)
         @test prox(p, β) ≈ prox(L2Penalty(1.0), β)
+        @test prox(p, β, 2.0) ≈ prox(L2Penalty(1.0), β, 2.0)
+        @test prox(p, β, 0.5) ≈ prox(L2Penalty(1.0), β, 0.5)
 
-        # TODO: add more tests
+        C = randn(10,10)
+        x = randn(10)
+        p2 = MahalanobisPenalty(C)
+        @test value(p2, x) ≈ 0.5*sum((C*x).^2)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,15 @@ using LearnBase, Penalties, Base.Test
         βcopy = deepcopy(β)
         @test prox(p, β) == zeros(10)
     end
+
+    @testset "MahalanobisPenalty" begin
+        p = MahalanobisPenalty(eye(10))
+        β = ones(10)
+        @test value(p, β) ≈ sum(β.^2)
+        @test prox(p, β) ≈ prox(L2Penalty(1.0), β)
+
+        # TODO: add more tests
+    end
 end
 
 @testset "ElementwisePenalty" begin


### PR DESCRIPTION
I would like to have a penalty of the form: `vecnorm(C*x).^2` for a specified matrix `C`. There are several contexts in which this is useful (for example, it can enforce a smoothness penalty on `x`)

Here is a derivation for the proximal operator (here I used `D` instead of `C`... sorry):

![image](https://cloud.githubusercontent.com/assets/636625/19132289/b1f2c912-8b07-11e6-9149-c56c0837ec44.png)

Right now I have some placeholder code that is quite slow:

``` julia
function _prox!{T <: Number}(p::MahalanobisPenalty{T}, A::AA{T, 1}, s::T)
    y = (p.C'p.C + (one(T)/s)*I) \ (A./s)
    copy!(A,y)
end
```

I would be much much better if we computed `Z = (p.C'p.C + (one(T)/s)*I)` and once and stored the LU factorization so that we could compute `Z \ (A./s)` very quickly on each iteration/call to `prox`.

Any thoughts on how to implement this into the code?
