### PR TITLE
fix the deprecated function sumabs2

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -75,7 +75,7 @@ function MahalanobisPenalty{T}(C::AA{T,2}, s::T=one(T))
     MahalanobisPenalty(one(T), C, C'C, s, lufact(C'C + I/s))
 end
 
-value{T <: Number}(p::MahalanobisPenalty{T}, x) = T(0.5) * p.λ * sumabs2(p.C * x)
+value{T <: Number}(p::MahalanobisPenalty{T}, x) = T(0.5) * p.λ * sum(abs2, p.C * x)
 
 function _prox!{T <: Number}(p::MahalanobisPenalty{T}, A::AA{T, 1}, sλ::T)
     if sλ != p.sλ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,7 +115,7 @@ end
         p = L1Penalty(.1)
         β = randn(10)
         storage = zeros(10)
-        @test value(p, β) ≈ .1 * sumabs(β)
+        @test value(p, β) ≈ .1 * sum(abs, β)
         @test deriv(p, β[1]) ≈ .1 * sign(β[1])
         grad!(storage, p, β)
         @test storage ≈ .1 * map(sign, β)
@@ -126,7 +126,7 @@ end
         p = L2Penalty(.1)
         β = randn(10)
         storage = zeros(10)
-        @test value(p, β) ≈ .5 * .1 * sumabs2(β)
+        @test value(p, β) ≈ .5 * .1 * sum(abs2, β)
         @test deriv(p, β[1]) ≈ .1 * β[1]
         grad!(storage, p, β)
         @test storage ≈ .1 * β
@@ -137,7 +137,7 @@ end
         p = ElasticNetPenalty(.1, .7)
         β = randn(10)
         storage = zeros(10)
-        @test value(p, β) ≈ .1 * (.7 * sumabs(β) + .3 * .5 * sumabs2(β))
+        @test value(p, β) ≈ .1 * (.7 * sum(abs, β) + .3 * .5 * sum(abs2, β))
         @test deriv(p, β[1]) ≈ .1 * .7 * sign(β[1]) + .1 * .3 * β[1]
         grad!(storage, p, β)
         @test storage ≈ .1 * .7 * map(sign, β) + .1 * .3 * β
@@ -151,13 +151,13 @@ end
         factor = rand(10)
         storage = zeros(10)
 
-        @test value(p, β) ≈ p.λ * sumabs(β)
-        @test value(p, β, factor) ≈ p.λ * sum(factor .* abs(β))
+        @test value(p, β) ≈ p.λ * sum(abs, β)
+        @test value(p, β, factor) ≈ p.λ * sum(factor .* abs.(β))
 
         grad!(storage, p, β)
-        @test storage ≈ p.λ * sign(β)
+        @test storage ≈ p.λ * sign.(β)
         grad!(storage, p, β, factor)
-        @test storage ≈ p.λ * sign(β) .* factor
+        @test storage ≈ p.λ * sign.(β) .* factor
 
         prox!(p, β)
         @test β ≈ map(x->PenaltyFunctions.soft_thresh(x, p.λ), βcopy)


### PR DESCRIPTION
Hello, there's a warning for `sum(abs2, x)` on Julia 0.6.
thanks.