### PR TITLE
Reexport LearnBase and set version bounds

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
-LearnBase
+LearnBase 0.1.2 0.2.0
 RecipesBase

--- a/src/PenaltyFunctions.jl
+++ b/src/PenaltyFunctions.jl
@@ -3,6 +3,9 @@ __precompile__(true)
 module PenaltyFunctions
 
 importall LearnBase
+# export LearnBase
+eval(Expr(:toplevel, Expr(:export, setdiff(names(LearnBase), [:LearnBase])...)))
+
 using RecipesBase
 
 export

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 module Tests
-using LearnBase, PenaltyFunctions, Base.Test
+using PenaltyFunctions, Base.Test
 P = PenaltyFunctions
 
 


### PR DESCRIPTION
1. The version bounds will serve the purpose of being able to move code etc upstream into LearnBase, without breaking tagged versions.

2. Reexporting LearnBase makes it a little more convenient to work with the package.