### PR TITLE
Enable broadcast for element penalties

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ buffer = zeros(5)
 # value
 value(p, x[1])        # evaluate on element
 value(p, x)           # evaluate on array
+value.(p, x)          # broadcast is supported as well
 value(p, x[1], s[1])  # evaluate on element, scaled by scalar
 value(p, x, s[1])     # evaluate on array, scaled by scalar
 value(p, x, s)        # evaluate on array, element-wise scaling

--- a/src/PenaltyFunctions.jl
+++ b/src/PenaltyFunctions.jl
@@ -59,4 +59,6 @@ Base.show(io::IO, p::Penalty) = print(io, name(p))
 
 include("elementpenalty.jl")
 include("arraypenalty.jl")
+
 end
+

--- a/src/elementpenalty.jl
+++ b/src/elementpenalty.jl
@@ -4,6 +4,10 @@ Penalties that are applied element-wise.
 abstract ElementPenalty <: Penalty
 abstract ConvexElementPenalty <: ElementPenalty  # only convex penalties have prox
 
+# Make broadcast work for ElementPenalty
+Base.getindex(p::ElementPenalty, idx) = p
+Base.size(::ElementPenalty) = ()
+
 #-------------------------------------------------------------------------------# methods
 value{T}(p::ElementPenalty, θ::T, s::T)     = s * value(p, θ)
 value{T}(p::ElementPenalty, θ::AA{T})       = sum(x -> value(p, x), θ)


### PR DESCRIPTION
In LossFunctions I define all the vectorized functions based on broadcasting the elementwise function. Should we follow that approach here instead of using map?

Related: we should avoid doing something like `sum(map((x,y) -> value(p, x, y), θ, s))`, which allocates a temporary array.