### PR TITLE
Mostly fixes for 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - nightly
 notifications:
   email: false
-matrix:
-  allow_failures:
-    - julia: nightly
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
-LearnBase 0.1.2 0.2.0
+julia 0.6-
+LearnBase 0.1.3
 RecipesBase

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  # - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  # - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  # - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  # - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
     - master
-    - /release-.*/
+    # - /release-.*/
 
 notifications:
   - provider: Email

--- a/src/PenaltyFunctions.jl
+++ b/src/PenaltyFunctions.jl
@@ -25,7 +25,7 @@ export
             MahalanobisPenalty,
     addgrad
 
-typealias AA{T, N} AbstractArray{T, N}
+const AA{T, N} = AbstractArray{T, N}
 
 
 # common functions

--- a/src/arraypenalty.jl
+++ b/src/arraypenalty.jl
@@ -1,7 +1,7 @@
 """
 Penalties that are applied to the entire parameter array only
 """
-abstract ArrayPenalty <: Penalty
+abstract type ArrayPenalty <: Penalty end
 name(p::ArrayPenalty) = replace(string(typeof(p)), "PenaltyFunctions.", "")
 
 #------------------------------------------------------------------# abstract methods
@@ -65,14 +65,12 @@ end
 
 
 #--------------------------------------------------------------------------------# scaled
-immutable ScaledArrayPenalty{P <: ArrayPenalty, λ} <: ArrayPenalty
+immutable ScaledArrayPenalty{T, P <: ArrayPenalty} <: ArrayPenalty
     penalty::P
-    ScaledArrayPenalty(pen::P) = (_scale_check(λ); new(pen))
+    λ::T
 end
-ScaledArrayPenalty{P, λ}(pen::P, ::Type{Val{λ}}) = ScaledArrayPenalty{P,λ}(pen)
-Base.show{P, λ}(io::IO, sp::ScaledArrayPenalty{P, λ}) = print(io, "$λ * ", sp.penalty)
+scaled(p::ArrayPenalty, λ::Number) = (_scale_check(λ); ScaledArrayPenalty(p, λ))
+Base.show{P, λ}(io::IO, sp::ScaledArrayPenalty{P, λ}) = print(io, "$λ * ($(sp.penalty))")
 
-scaled(p::ArrayPenalty, λ::Number) = ScaledArrayPenalty(p, Val{λ})
-
-value{P, λ}(p::ScaledArrayPenalty{P, λ}, θ::AA) = λ * value(p.penalty, θ)
-prox!{P, λ, T}(p::ScaledArrayPenalty{P, λ}, θ::AA{T}) = prox!(p.penalty, θ, λ)
+value{T}(p::ScaledArrayPenalty{T}, θ::AA{T}) = p.λ * value(p.penalty, θ)
+prox!{T}(p::ScaledArrayPenalty{T}, θ::AA{T}) = prox!(p.penalty, θ, p.λ)

--- a/src/arraypenalty.jl
+++ b/src/arraypenalty.jl
@@ -70,7 +70,8 @@ immutable ScaledArrayPenalty{T, P <: ArrayPenalty} <: ArrayPenalty
     λ::T
 end
 scaled(p::ArrayPenalty, λ::Number) = (_scale_check(λ); ScaledArrayPenalty(p, λ))
-Base.show{P, λ}(io::IO, sp::ScaledArrayPenalty{P, λ}) = print(io, "$λ * ($(sp.penalty))")
+
+Base.show(io::IO, sp::ScaledArrayPenalty) = print(io, "$(sp.λ) * ($(sp.penalty))")
 
 value{T}(p::ScaledArrayPenalty{T}, θ::AA{T}) = p.λ * value(p.penalty, θ)
 prox!{T}(p::ScaledArrayPenalty{T}, θ::AA{T}) = prox!(p.penalty, θ, p.λ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,15 +12,14 @@ array_penalties = [NuclearNormPenalty(), GroupLassoPenalty(),
 penalty_list = vcat(element_penalties, array_penalties)
 
 info("Show methods:")
-@testset "Show" begin
-    for p in penalty_list
-        println(p)
-        println(scaled(p, .1))
-    end
-    println("\n")
+for p in penalty_list
+    print_with_color(:red, "  > $(string(p))\n")
+    print_with_color(:cyan, "  > $(string(scaled(p, .1)))\n")
 end
 
 #---------------------------------------------------------------------------# Begin Tests
+println("\n")
+info("Begin Actual Tests")
 @testset "Common" begin
     @test P.soft_thresh(1.0, 0.5) == 0.5
     @test P.soft_thresh!(ones(5), .5) == .5 * ones(5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,8 +33,11 @@ end
         @testset "$(P.name(p))" begin
             @test value(p, θ)   ≈ v1
             @test deriv(p, θ)   ≈ v2
-            if supertype(typeof(p)) == ConvexElementPenalty
+            @test value.(p, fill(θ, 5)) ≈ fill(v1, 5)
+            @test deriv.(p, fill(θ, 5)) ≈ fill(v2, 5)
+            if isa(p, ConvexElementPenalty)
                 @test prox(p, θ, s) ≈ v3
+                @test prox.(p, fill(θ, 5), s) ≈ fill(v3, 5)
             end
         end
     end


### PR DESCRIPTION
- Bump requirement to Julia 0.6-
- Changed scaled penalties to have lambda be a field instead of a type parameter (maybe this should've been a separate PR)

Since PenaltyFunctions is not yet in Metadata, I think we should wait for 0.6.  We can create a 0.5 branch for people to check out if they'd like.