### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 LearnBase 0.1.3 0.2.0
 RecipesBase


### PR DESCRIPTION
`abstract type` syntax wouldn't work in early 0.6.0-dev versions,
so the package shouldn't claim to support them