### PR TITLE
allow * to construct scaled

### DIFF
--- a/src/elementpenalty.jl
+++ b/src/elementpenalty.jl
@@ -239,6 +239,7 @@ end
 scaled(p::ElementPenalty, λ::Number) = (_scale_check(λ); ScaledElementPenalty(p, λ))
 Base.show(io::IO, sp::ScaledElementPenalty) = print(io, "$(sp.λ) * ($(sp.penalty))")
 
+Base.:(*)(λ::Number, p::ElementPenalty) = scaled(p, λ)
 
 value(p::ScaledElementPenalty{<:Number}, θ::Number) = p.λ * value(p.penalty, θ)
 deriv(p::ScaledElementPenalty{<:Number}, θ::Number) = p.λ * deriv(p.penalty, θ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,6 +166,7 @@ end
         # FIXME: @inference broken during tests (not in REPL though)
         #        only for ElasticNetPenalty{Float64} for some reason
         @test value(s, x) ≈ value(p, x, .1)
+        @test value(s, x) == value(.1 * p, x)
         @test @inferred(deriv(s, x[1])) ≈ deriv(p, x[1], .1)
         @test @inferred(grad(s, x))     ≈ grad(p, x, .1)
         if typeof(p) <: ConvexElementPenalty


### PR DESCRIPTION
Just as for losses, this allows:

```julia
.1 * L2Penalty()
```